### PR TITLE
feat: added a parsedDate check in the update

### DIFF
--- a/code/server/src/controllers/documentController.ts
+++ b/code/server/src/controllers/documentController.ts
@@ -251,6 +251,12 @@ class DocumentController {
     }
 
     async updateDocument(documentData: DocumentEditData, documentGeoData: DocumentGeoData): Promise<boolean> {
+        if(documentData.issuanceDate) {
+            let actualParsedDate: Date = await this.dao.getParsedDate(documentData.documentID);
+            if(this.helper.isValidDate(documentData.issuanceDate, actualParsedDate.toISOString().split("T")[0]))
+                documentData.parsedDate = actualParsedDate;
+        }
+
         if(this.helper.isAssignedToKiruna(documentGeoData)) 
             return await this.helper.nodeAssignedToKiruna(documentData, documentGeoData, this.dao, Modality.UPDATE);
 

--- a/code/server/src/dao/documentDAO.ts
+++ b/code/server/src/dao/documentDAO.ts
@@ -499,6 +499,20 @@ class DocumentDAO {
             await conn?.release();
         }
     }
+
+    async getParsedDate(documentID: number): Promise<Date> {
+        let conn;
+        try {
+            conn = await db.getConnection();
+            const sql = `SELECT parsedDate FROM document WHERE documentID = ?`
+            const result = await conn.query(sql, [documentID]);
+            return new Date(new Date(result[0].parsedDate).getTime() - (new Date(result[0].parsedDate).getTimezoneOffset() * 60000));
+        } catch(err: any) {
+            throw new InternalServerError();
+        } finally {
+            await conn?.release();
+        }
+    }
 }
 
 export { DocumentDAO };


### PR DESCRIPTION
Now if the old parsedDate is in range of the new issuanceDate the coordinate won't change